### PR TITLE
[PWEB-12817] Rails 5.1 Param Safety

### DIFF
--- a/lib/virtus/attribute_set.rb
+++ b/lib/virtus/attribute_set.rb
@@ -193,9 +193,13 @@ module Virtus
     #
     # @api private
     def coerce(attributes)
-      ::Hash.try_convert(attributes) or raise(
-        NoMethodError, "Expected #{attributes.inspect} to respond to #to_hash"
-      )
+      if attributes.respond_to?(:to_unsafe_hash)
+        attributes.to_unsafe_hash
+      elsif hash_attributes = ::Hash.try_convert(attributes)
+        hash_attributes
+      else
+        raise( NoMethodError, "Expected #{attributes.inspect} to respond to #to_hash" )
+      end
     end
 
     # @api private

--- a/spec/unit/virtus/attributes_writer_spec.rb
+++ b/spec/unit/virtus/attributes_writer_spec.rb
@@ -14,6 +14,32 @@ describe Virtus, '#attributes=' do
 
       expect(subject.test).to eql('Hello World')
     end
+
+    context "with Rails 5 parameters" do
+      class FakeParams
+
+        def initialize(hash)
+          @hash = hash
+        end
+
+        def to_hash
+          raise "Cannot be called on unsafe params"
+        end
+
+        def to_unsafe_hash
+          @hash
+        end
+      end
+
+      it "safely assigns the hash" do
+        subject.attributes = FakeParams.new({ :test => 'Hello World' })
+        expect(subject.test).to eql('Hello World')
+      end
+
+      it "handles properly if the attributes are not hash like" do
+        expect { subject.attributes = 1 }.to raise_error(NoMethodError)
+      end
+    end
   end
 
   context 'with a class' do


### PR DESCRIPTION
# About

This applies a Rails 5.1 PR from the Virtus gem into our fork, along a `branch/1_0_5` which we will maintain for long running changes. Hopefully this all gets deprecated soon.

Once this is ready, I will point Babylon to this branch of the fork.

## Related PRs

https://github.com/solnic/virtus/pull/388

## Related JIRA

https://perchwell.atlassian.net/issues/PWEB-12817?jql=ORDER%20BY%20created%20DESC